### PR TITLE
add patch by article id functionality

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -153,19 +153,19 @@ describe('/api/articles', () => {
                     expect(res.body.article).toHaveProperty('votes', -50);
                 });
         });
-        test('400: empty object in request receives error', () => {
+        test('400: request is in wrong format', () => {
             return request(app)
                 .patch('/api/articles/3')
-                .send({})
+                .send({ "inc_vote": 50 })
                 .expect(400)
                 .then((response) => {
                     expect(response.body.msg).toBe('bad request');
                 });
         });
-        test('400: request is in wrong format', () => {
+        test('400: request value is not a number', () => {
             return request(app)
                 .patch('/api/articles/3')
-                .send({ "inc_vote": 50 })
+                .send({ "inc_vote": 'fifty' })
                 .expect(400)
                 .then((response) => {
                     expect(response.body.msg).toBe('bad request');

--- a/app.js
+++ b/app.js
@@ -2,14 +2,17 @@ const express = require('express');
 
 const { getTopics } = require('./controllers/topics.controller.js');
 const { getUsers } = require('./controllers/users.controller.js');
-const { getArticleByID } = require('./controllers/articles.controller.js');
+const { getArticleByID, editVotes } = require('./controllers/articles.controller.js');
 const { invalidRequest } = require('./controllers/errors.controller.js');
 
 const app = express();
 
+app.use(express.json());
+
 app.get('/api/topics', getTopics);
 app.get('/api/users', getUsers);
 app.get('/api/articles/:article_id', getArticleByID);
+app.patch('/api/articles/:article_id', editVotes);
 app.all('/*', invalidRequest);
 
 app.use((err, req, res, next) => {

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -1,4 +1,4 @@
-const { selectArticle } = require('../models/articles.model.js');
+const { selectArticle, updateVotes } = require('../models/articles.model.js');
 
 exports.getArticleByID = (req, res, next) => {
     const articleId = req.params.article_id;
@@ -6,6 +6,17 @@ exports.getArticleByID = (req, res, next) => {
         .then((articleData) => {
             res.status(200).send({ article: articleData });
         })
+        .catch((err) => {
+            next(err);
+        });
+};
+
+exports.editVotes = (req, res, next) => {
+    const articleId = req.params.article_id;
+    const votes = req.body.inc_votes;
+    updateVotes(articleId, votes).then((articleData) => {
+        res.status(201).send({ article: articleData });
+    })
         .catch((err) => {
             next(err);
         });

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -2,7 +2,9 @@ const db = require('../db/connection.js');
 
 exports.selectArticle = (articleId) => {
     return db
-        .query(`SELECT * FROM articles WHERE article_id = $1`, [articleId])
+        .query(`SELECT * 
+                FROM articles 
+                WHERE article_id = $1;`, [articleId])
         .then((result) => {
             if (result.rows.length === 0) {
                 return Promise.reject({ status: 404, msg: 'article not found' });
@@ -10,4 +12,35 @@ exports.selectArticle = (articleId) => {
                 return result.rows[0];
             };
         });
+};
+
+exports.updateVotes = (articleId, votes) => {
+    if (votes > 0) {
+        return db
+            .query(`UPDATE articles 
+                    SET votes = votes + $1 
+                    WHERE article_id = $2 
+                    RETURNING *;`, [votes, articleId])
+            .then((result) => {
+                if (result.rows.length === 0) {
+                    return Promise.reject({ status: 404, msg: 'article not found' });
+                } else {
+                    return result.rows[0];
+                };
+            });
+    } else {
+        const convertToPositive = Math.abs(votes);
+        return db
+            .query(`UPDATE articles 
+                    SET votes = votes - $1 
+                    WHERE article_id = $2 
+                    RETURNING *;`, [convertToPositive, articleId])
+            .then((result) => {
+                if (result.rows.length === 0) {
+                    return Promise.reject({ status: 404, msg: 'article not found' });
+                } else {
+                    return result.rows[0];
+                };
+            });
+    };
 };


### PR DESCRIPTION
I've used the convertTimeStamptoDate for tests where I am querying the database to check it has been correctly updated, previously I was manually coverting the timestamp and adding it to the tests when I have been testing the response, I tried to update my previous tests for testing the server response to use convertTimeStampToDate, however, I cannot get this to work as the function always returns the date and time as a string where it is in a different format in the response. So everything is working at the moment but where I am testing the server response I have manually converted the timestamp rather than using the function, not sure if that is OK or not?